### PR TITLE
Adds a few conferences, adds TBA and directions how to run locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+# This seems to be the version GitHub uses when looking at a build. It's quite old so it might be a source of error later on.
+gem "jekyll", "~> 3.10.0"
+

--- a/README.md
+++ b/README.md
@@ -92,3 +92,18 @@ The timezone is specified in [tz format][1]. Unlike abbreviations (e.g. EST), th
 [1]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 [2]: https://www.timeanddate.com/time/zones/aoe
 
+## Running locally
+
+The site is hosted using [GitHub Pages](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll) and build with [jekyll](https://jekyllrb.com/)
+
+If you want to see your changes locally before committing them you can install [jekyll](https://jekyllrb.com/docs/) locally or you can use docker to do everything for you:
+```
+docker run --rm \
+  --volume="$PWD:/srv/jekyll:Z" \
+  --volume="jekyll_bundler_cache:/usr/local/bundle" \
+  --publish 4000:4000 \
+  jekyll/jekyll \
+  sh -c "bundle config set path '/usr/local/bundle' && bundle install && jekyll serve"
+```
+
+This will host the page on http://0.0.0.0:4000/ for you to check. This will also allow live edits, so you don't need to restart the server after edit. It will also create a new volume to cache the bundler gems. You can either remove the line `--volume="jekyll_bundler_cache:/usr/local/bundle" \` or `docker volume rm jekyll_bundler_cache` will also clean everything up.

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -54,8 +54,61 @@
   place: Toronto, CA
   tags: [HARD, SOFT, HUCO, ETPO, CONF]
 
+- name: ACM e-Energy
+  year: 2025
+  date: "June 17 – 20"
+  description: "ACM International Conference on Future and Sustainable Energy Systems"
+  link: https://energy.acm.org/conferences/eenergy/2025/index.php
+  deadline:
+    - TBA
+  place: Rotterdam, Netherlands
+  tags: [HARD, SOFT, HUCO, ETPO, CONF]
+
+- name: WCST
+  year: 2025
+  date: "TBA"
+  description: "World Congress on Sustainable Technologies"
+  link: https://www.wcst.org/
+  deadline:
+    - "2025-05-25 23:59"
+  place: University of Oxford, UK
+  tags: [HARD, SOFT, HUCO, ETPO, CONF]
+
+
+
 
 ## 2024
+
+- name: IEEE GreenCom-2024
+  year: 2024
+  date: "Aug 19"
+  description: "IEEE International Conference on Green Computing and
+Communications"
+  link: https://ieee-cybermatics.org/2024/greencom/index.php
+  deadline:
+  place: Copenhagen, Denmark
+  tags: [HARD, SOFT, HUCO, ETPO, CONF]
+
+- name: IGSC
+  year: 2024
+  date: "Nov 2"
+  description: "The 15th International Green and Sustainable Computing Conference"
+  link: https://www.igscc.org/
+  deadline:
+      - "2024-08-05 23:59"
+  place: Austin, TX, USA
+  tags: [HARD, SOFT, HUCO, ETPO, CONF]
+
+- name: Greens Workshop
+  year: 2024
+  date: "April 29"
+  description: "9th International Workshop on Green and Sustainable Software"
+  link: https://greensworkshop.github.io/
+  deadline:
+      - "2024-11-11 23:59"
+  place: Ottawa (Canada)
+  tags: [HARD, SOFT, HUCO, ETPO, SHOP]
+
 
 - name: LOCO
   year: 2024
@@ -239,7 +292,7 @@
     - "2023-01-01 23:59"
   place: Antwerp, Belgium
   tags: [HARD, SOFT, SHOP]
- 
+
 - name: Solidarity and Disruption
   year: 2022
   date: "November 11"
@@ -309,7 +362,7 @@
     - "2022-01-01 23:59"
   place: San Diego, USA
   tags: [HARD, SHOP]
- 
+
 - name: HotCarbon
   year: 2022
   date: "July 10"
@@ -349,7 +402,7 @@
     - "2022-01-31 23:59"
   place: Online
   tags: [HARD, SOFT, SHOP]
- 
+
 - name: CHI
   year: 2022
   date: "April 30 – May 05"

--- a/index.html
+++ b/index.html
@@ -81,8 +81,12 @@ in a pull request</a> or drop me an
                       Deadline:
                       {% endif %}
                     <span class="deadline-time">
-                      {{ deadline }}
-                    </span>
+                      {% if deadline == "TBA" or deadline == nil %}
+                        TBA
+                      {% else %}
+                        {{ deadline }}
+                      {% endif %}
+                        </span>
                     <div class="meta">
                       {{ conf.comment }}
                     </div>


### PR DESCRIPTION
This PR adds the following conferences or workshops:
- ACM e-Energy
- WCST
- IEEE GreenCom-2024
- IGSC
- Greens Workshop

it also adds the possibility to add `TBA` as a deadline if you know when the conference will be but not when the call for papers is due. 

it also adds a little section to the README on how to build and run the system locally. 